### PR TITLE
fix clone not working if T:!Clone

### DIFF
--- a/src/mpsc/bounded.rs
+++ b/src/mpsc/bounded.rs
@@ -3,7 +3,6 @@ use crate::semaphore::Inner;
 use futures_util::future::poll_fn;
 use std::task::{Context, Poll};
 
-#[derive(Clone)]
 pub struct Tx<T>(chan::Tx<T, Inner>);
 
 pub struct Rx<T>(chan::Rx<T, Inner>);
@@ -32,6 +31,12 @@ impl<T> Tx<T> {
 
     pub fn same_channel(&self, other: &Self) -> bool {
         self.0.same_channel(&other.0)
+    }
+}
+
+impl<T> Clone for Tx<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 

--- a/src/mpsc/unbounded.rs
+++ b/src/mpsc/unbounded.rs
@@ -5,7 +5,6 @@ use super::{
 use futures_util::future::poll_fn;
 use std::task::{Context, Poll};
 
-#[derive(Clone)]
 pub struct Tx<T>(chan::Tx<T, Unlimited>);
 
 pub struct Rx<T>(chan::Rx<T, Unlimited>);
@@ -27,6 +26,12 @@ impl<T> Tx<T> {
 
     pub fn same_channel(&self, other: &Self) -> bool {
         self.0.same_channel(&other.0)
+    }
+}
+
+impl<T> Clone for Tx<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 


### PR DESCRIPTION
```rust
struct CantClone(i32);
let (tx, mut rx) = mpsc::bounded::channel::<CantClone>(10);
let tx2 = tx.clone();
//          ^ fix error here
```