### PR TITLE
fix panic "already borrowed"

### DIFF
--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -401,15 +401,17 @@ impl Drop for Acquire<'_> {
             return;
         }
 
-        // This is where we ensure safety. The future is being dropped,
-        // which means we must ensure that the waiter entry is no longer stored
-        // in the linked list.
-        let mut waiters = self.semaphore.waiters.borrow_mut();
+        {
+            // This is where we ensure safety. The future is being dropped,
+            // which means we must ensure that the waiter entry is no longer stored
+            // in the linked list.
+            let mut waiters = self.semaphore.waiters.borrow_mut();
 
-        // remove the entry from the list
-        let node = NonNull::from(&mut self.node);
-        // Safety: we have locked the wait list.
-        unsafe { waiters.queue.remove(node) };
+            // remove the entry from the list
+            let node = NonNull::from(&mut self.node);
+            // Safety: we have locked the wait list.
+            unsafe { waiters.queue.remove(node) };
+        }
 
         let acquired_permits = self.num_permits as usize - *self.node.state.borrow();
         if acquired_permits > 0 {


### PR DESCRIPTION
This pull request fixes a panic caused by a double borrow of `waiters`, resulting in the panic "already borrowed." 
The fix moves the `borrow_mut()` of `waiters` into a scoped block, ensuring the borrow is released before calling `add_permits()`. This prevents the double borrow and resolves the panic.